### PR TITLE
Specify library dependencies in library.properties

### DIFF
--- a/library.properties
+++ b/library.properties
@@ -6,3 +6,4 @@ sentence=SDConfigCommand streamlines reading settings from a config file on SD c
 paragraph=SDConfigCommand can read standardised text files stored on a SD card, parse and tokenise them into commands and values. The library can also write over existing settings but it is currently slow to do so. For every line on the config file this library reads, it will callback a user-specified function. The user can access the current command and values, then decide the next action, such as verifying commands and storing values in variables. With regards to writing over existing settings, user can choose one command, and the library will search for the command in the config file and replace the whole setting line with a new value. The library does not add or remove settings.
 url=https://github.com/cygig/SDConfigCommand
 architectures=*
+depends=SD


### PR DESCRIPTION
Specifying the library dependencies in the `depends` field of library.properties causes the Arduino Library Manager (Arduino IDE 1.8.10 and newer) to offer to install any missing dependencies during installation of this library.

`arduino-cli lib install` will automatically install the dependencies (arduino-cli 0.7.0 and newer).

Reference:
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#libraryproperties-file-format