### PR TITLE
Fix datatype in callback_Function declaration

### DIFF
--- a/src/SDConfigCommand.h
+++ b/src/SDConfigCommand.h
@@ -57,7 +57,7 @@ class SDConfigCommand {
     float getValueFloat();
 
   private:
-    (*callback_Function)();
+    void (*callback_Function)();
     File cFile;
     char filename[13];
     int cs; // chip select pin


### PR DESCRIPTION
Fix syntax error missing data type in class callback function declaration.